### PR TITLE
limiting image and video loading 

### DIFF
--- a/src/components/ClientGallery.tsx
+++ b/src/components/ClientGallery.tsx
@@ -51,7 +51,7 @@ const ClientGallery = (props: { media: DB_MediaType[] }) => {
                     <Users2 className="text-primary h-8 w-8" />
                     <div>
                       <h3 className="text-foreground text-lg font-semibold">
-                        {props.media.length} Photos and Videos shared
+                        Last {props.media.length} Photos and Videos shared
                       </h3>
                       <p className="text-muted-foreground">
                         From our wonderful guests

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,9 +1,9 @@
-import { fetchMedia } from "~/server/actions/actions";
+import { fetchLimitedMedia } from "~/server/actions/actions";
 import ClientGallery from "./ClientGallery";
 import { Clapperboard } from "lucide-react";
 
 const Gallery = async () => {
-  const media = await fetchMedia();
+  const media = await fetchLimitedMedia();
 
   if (media instanceof Error) {
     return (

--- a/src/server/actions/actions.ts
+++ b/src/server/actions/actions.ts
@@ -185,3 +185,14 @@ export const fetchMedia = async (featured = false) => {
 
   return result;
 };
+
+export const fetchLimitedMedia = async () => {
+  const result = await QUERIES.getLastTwentyMedia();
+  console.log(result);
+
+  if (result instanceof Error) {
+    return new Error(result.message);
+  }
+
+  return result;
+};

--- a/src/server/db/queries.ts
+++ b/src/server/db/queries.ts
@@ -95,6 +95,20 @@ export const QUERIES = {
       return new Error("Failed to fetch uploaded media");
     }
   },
+
+  getLastTwentyMedia: async function (): Promise<DB_MediaType[] | [] | Error> {
+    try {
+      const media = await db
+        .select()
+        .from(media_table)
+        .orderBy(desc(media_table.createdAt))
+        .limit(20);
+      return media;
+    } catch (error) {
+      console.error("Error fetching media", error);
+      return new Error("Failed to fetch uploaded media");
+    }
+  },
 };
 
 export const MUTATIONS = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gallery now displays only the 20 most recent photos and videos shared, providing a more focused view of recent media.

* **Style**
  * Updated the gallery header text to clarify that the displayed count refers to the most recent items shared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->